### PR TITLE
Foreman sets the root password hash in a fact named $::root_pw.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@
 #  include '::root'
 #
 class root (
-  $password                    = undef,
+  $password                    = $::root::params::password,
   $comment                     = $::root::params::comment,
   $shell                       = $::root::params::shell,
   $ssh_authorized_keys_ensure  = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,6 +2,7 @@ class root::params {
 
   $comment = 'root'
   $shell = '/bin/bash'
+  $password = $::root_pw
 
   case $::operatingsystem {
     'Gentoo': {


### PR DESCRIPTION
This allows Foreman ENC users to automatically set the root password via the ENC while still leaving the value as undef for anyone without $::root_pw set.
