### PR TITLE
Added optional timeout for root shell

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,7 @@ class root (
   $ssh_authorized_keys_content = undef,
   $ssh_authorized_keys_source  = undef,
   $email_recipient             = undef,
+  $root_timeout                = undef,
 ) inherits ::root::params {
 
   # The user. No, we don't want to support 'absent' :-)
@@ -56,6 +57,16 @@ class root (
     exec { 'root-newaliases':
       command     => '/usr/bin/newaliases',
       refreshonly => true,
+    }
+  }
+
+  # We usually don't want root terminals to sit idle for too long
+  if $root_timeout {
+    file {'/etc/profile.d/999_root_timeout.sh':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template('root/root_timeout.sh'),
     }
   }
 

--- a/templates/root_timeout.sh
+++ b/templates/root_timeout.sh
@@ -1,0 +1,4 @@
+if [[ "x$EUID" == "x0" ]] ; then
+  TMOUT=<%= @root_timeout %>
+fi
+


### PR DESCRIPTION
This seemed like the rational place for me to add an optional timeout for root terminals.
